### PR TITLE
Feature: type of new text event

### DIFF
--- a/src/MidiEvent/TextEvent.cpp
+++ b/src/MidiEvent/TextEvent.cpp
@@ -117,3 +117,15 @@ QString TextEvent::textTypeString(int type)
     }
     return QString();
 }
+
+int TextEvent::typeForNewEvents = TEXT;
+
+void TextEvent::setTypeForNewEvents(int type)
+{
+    typeForNewEvents = type;
+}
+
+int TextEvent::getTypeForNewEvents()
+{
+    return typeForNewEvents;
+}

--- a/src/MidiEvent/TextEvent.h
+++ b/src/MidiEvent/TextEvent.h
@@ -54,9 +54,13 @@ public:
     QString typeString();
     static QString textTypeString(int type);
 
+    static int getTypeForNewEvents();
+    static void setTypeForNewEvents(int type);
+
 private:
     int _type;
     QString _text;
+    static int typeForNewEvents;
 };
 
 #endif

--- a/src/gui/EventWidget.cpp
+++ b/src/gui/EventWidget.cpp
@@ -509,6 +509,7 @@ void EventWidgetDelegate::setModelData(QWidget* editor, QAbstractItemModel* mode
                 if ((newType == TextEvent::TRACKNAME) && (oldType != newType)) {
                     event->track()->setNameEvent(c);
                 }
+                TextEvent::setTypeForNewEvents(newType);
             }
         }
         break;

--- a/src/tool/NewNoteTool.cpp
+++ b/src/tool/NewNoteTool.cpp
@@ -229,7 +229,7 @@ bool NewNoteTool::release()
                 event = new TextEvent(16, track);
                 TextEvent* textEvent = (TextEvent*)event;
                 textEvent->setText("New Text Event");
-                textEvent->setType(TextEvent::TEXT);
+                textEvent->setType(TextEvent::getTypeForNewEvents());
                 int startMs = matrixWidget->msOfXPos(xPos);
                 int startTick = file()->tick(startMs);
                 file()->channel(16)->insertEvent(event, startTick);


### PR DESCRIPTION
When adding a new text event, make its type match the last edited one.

This will make it faster and easier to insert a bunch of lyrics or
markers in a row.