### PR TITLE
Hotfix: excessive CPU use in the MIDI SenderThread

### DIFF
--- a/src/midi/SenderThread.h
+++ b/src/midi/SenderThread.h
@@ -19,8 +19,10 @@
 #ifndef SENDERTHREAD_H_
 #define SENDERTHREAD_H_
 
+#include <QMutex>
 #include <QQueue>
 #include <QThread>
+#include <QWaitCondition>
 
 #include "MidiOutput.h"
 
@@ -34,6 +36,8 @@ public:
 private:
     QQueue<MidiEvent*>* _eventQueue;
     QQueue<MidiEvent*>* _noteQueue;
+    QMutex* _mutex;
+    QWaitCondition* _waitCondition;
 };
 
 #endif


### PR DESCRIPTION
I ran a profiler to determine where the runaway CPU usage appeared, and it
showed up as dominated by calls to msleep() in SenderThread.  I did the
standard replacement of the busy loop with a mutex and wait condition, which
solved the problem.  Initial interactive testing showed no degradation of
timing accuracy in playback.