### PR TITLE
Hotfix: don't automatically switch to the event widget tab when the selection changes

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -440,7 +440,6 @@ MainWindow::MainWindow(QString initFile)
     Selection::_eventWidget = _eventWidget;
     lowerTabWidget->addTab(_eventWidget, "Event");
     MidiEvent::setEventWidget(_eventWidget);
-    connect(_eventWidget, SIGNAL(selectionChangedByTool(bool)), this, SLOT(showEventWidget(bool)));
 
     // below add two rows for choosing track/channel new events shall be assigned to
     QWidget* chooser = new QWidget(rightSplitter);


### PR DESCRIPTION
That behavior may be useful during development, but for actual users, it's not good form to override their choice of which tab to view.