### PR TITLE
Feature: rearrange the tab layout

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -112,7 +112,6 @@ public slots:
 
     void renameTrackMenuClicked(QAction* action);
     void removeTrackMenuClicked(QAction* action);
-    void showEventWidget(bool show);
     void showTrackMenuClicked(QAction* action);
     void muteTrackMenuClicked(QAction* action);
 
@@ -193,7 +192,6 @@ private:
         *_moveSelectedEventsToTrackMenu, *_moveSelectedEventsToChannelMenu,
         *_pasteToTrackMenu, *_pasteToChannelMenu, *_selectAllFromTrackMenu, *_selectAllFromChannelMenu;
 
-    QTabWidget* lowerTabWidget;
     QAction *_colorsByChannel, *_colorsByTracks;
 
     QComboBox *_chooseEditTrack, *_chooseEditChannel;


### PR DESCRIPTION
Use a single tab notebook on the right containing events, protocol, tracks, and
channels.  This allows the current tab to stretch the whole height of the
window, displaying more data at once without scrolling.