### PR TITLE
Hotfix: hide selection changes in protocol

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -577,6 +577,7 @@ void MainWindow::setFile(MidiFile* file)
     connect(file, SIGNAL(recalcWidgetSize()), mw_matrixWidget, SLOT(calcSizes()));
     connect(file->protocol(), SIGNAL(actionFinished()), this, SLOT(markEdited()));
     connect(file->protocol(), SIGNAL(actionFinished()), eventWidget(), SLOT(reload()));
+    connect(eventWidget(), SIGNAL(selectionChangedByTool(bool)), eventWidget(), SLOT(reload()));
     connect(file->protocol(), SIGNAL(actionFinished()), this, SLOT(checkEnableActionsForSelection()));
     mw_matrixWidget->setFile(file);
     updateChannelMenu();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1831,7 +1831,6 @@ void MainWindow::selectAllFromChannel(QAction* action)
         return;
     }
     int channel = action->data().toInt();
-    file->protocol()->startNewAction("Select all events from channel " + QString::number(channel));
     EventTool::clearSelection();
     file->channel(channel)->setVisible(true);
     foreach (MidiEvent* e, file->channel(channel)->eventMap()->values()) {
@@ -1840,8 +1839,6 @@ void MainWindow::selectAllFromChannel(QAction* action)
         }
         EventTool::selectEvent(e, false);
     }
-
-    file->protocol()->endAction();
 }
 
 void MainWindow::selectAllFromTrack(QAction* action)
@@ -1852,7 +1849,6 @@ void MainWindow::selectAllFromTrack(QAction* action)
     }
 
     int track = action->data().toInt();
-    file->protocol()->startNewAction("Select all events from track " + QString::number(track));
     EventTool::clearSelection();
     file->track(track)->setHidden(false);
     for (int channel = 0; channel < 16; channel++) {
@@ -1863,7 +1859,6 @@ void MainWindow::selectAllFromTrack(QAction* action)
             }
         }
     }
-    file->protocol()->endAction();
 }
 
 void MainWindow::selectAll()
@@ -1873,15 +1868,13 @@ void MainWindow::selectAll()
         return;
     }
 
-    file->protocol()->startNewAction("Select all");
-
     for (int i = 0; i < 16; i++) {
         foreach (MidiEvent* event, file->channel(i)->eventMap()->values()) {
             EventTool::selectEvent(event, false, true);
         }
     }
 
-    file->protocol()->endAction();
+    updateAll();
 }
 
 void MainWindow::transposeNSemitones()

--- a/src/gui/SelectionNavigator.cpp
+++ b/src/gui/SelectionNavigator.cpp
@@ -26,7 +26,6 @@
 #include "../midi/MidiChannel.h"
 #include "../midi/MidiFile.h"
 #include "../midi/MidiTrack.h"
-#include "../protocol/Protocol.h"
 #include "../tool/EventTool.h"
 #include "../tool/Selection.h"
 
@@ -87,10 +86,7 @@ void SelectionNavigator::navigate(qreal searchAngle)
     }
 
     if (!newSelectedEvent) return;
-    Protocol* protocol = file->protocol();
-    protocol->startNewAction("Tweak selection");
     EventTool::selectEvent(newSelectedEvent, true);
-    protocol->endAction();
     mainWindow->updateAll();
 }
 

--- a/src/tool/SelectTool.cpp
+++ b/src/tool/SelectTool.cpp
@@ -21,7 +21,6 @@
 #include "../MidiEvent/NoteOnEvent.h"
 #include "../gui/MatrixWidget.h"
 #include "../midi/MidiFile.h"
-#include "../protocol/Protocol.h"
 #include "StandardTool.h"
 
 SelectTool::SelectTool(int type)
@@ -99,7 +98,6 @@ bool SelectTool::release()
     if (!file()) {
         return false;
     }
-    file()->protocol()->startNewAction("Selection changed", image());
     ProtocolEntry* toCopy = copy();
 
     if (!QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
@@ -153,7 +151,6 @@ bool SelectTool::release()
     y_rect = 0;
 
     protocol(toCopy, this);
-    file()->protocol()->endAction();
     if (_standardTool) {
         Tool::setCurrentTool(_standardTool);
         _standardTool->move(mouseX, mouseY);

--- a/src/tool/StandardTool.cpp
+++ b/src/tool/StandardTool.cpp
@@ -25,7 +25,6 @@
 #include "../MidiEvent/MidiEvent.h"
 #include "../gui/MatrixWidget.h"
 #include "../midi/MidiFile.h"
-#include "../protocol/Protocol.h"
 #include "Selection.h"
 
 #define NO_ACTION 0
@@ -145,11 +144,9 @@ bool StandardTool::press(bool leftClick)
 
             case SIZE_CHANGE_ACTION: {
                 if (!onSelectedEvent) {
-                    file()->protocol()->startNewAction("Selection changed", image());
                     ProtocolEntry* toCopy = copy();
                     EventTool::selectEvent(event, !Selection::instance()->selectedEvents().contains(event));
                     protocol(toCopy, this);
-                    file()->protocol()->endAction();
                 }
                 Tool::setCurrentTool(sizeChangeTool);
                 sizeChangeTool->move(mouseX, mouseY);
@@ -159,11 +156,9 @@ bool StandardTool::press(bool leftClick)
 
             case MOVE_ACTION: {
                 if (!onSelectedEvent) {
-                    file()->protocol()->startNewAction("Selection changed", image());
                     ProtocolEntry* toCopy = copy();
                     EventTool::selectEvent(event, !Selection::instance()->selectedEvents().contains(event));
                     protocol(toCopy, this);
-                    file()->protocol()->endAction();
                 }
                 /* TODO reenable
 					if(altGrPressed){


### PR DESCRIPTION
Don't show selection changes as their own steps in the protocol (undo history).