### PR TITLE
Hotfix: re-enable directionally constrained move in the standard tool

### DIFF
--- a/src/tool/StandardTool.cpp
+++ b/src/tool/StandardTool.cpp
@@ -165,14 +165,13 @@ bool StandardTool::press(bool leftClick)
                     protocol(toCopy, this);
                     file()->protocol()->endAction();
                 }
-                /* TODO reenable
-					if(altGrPressed){
+					if(QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)){
 						moveTool->setDirections(true, false);
-					} else if(spacePressed){
+					} else if(QApplication::keyboardModifiers().testFlag(Qt::AltModifier)){
 						moveTool->setDirections(false, true);
 					} else {
 						moveTool->setDirections(true, true);
-					} */
+					}
                 Tool::setCurrentTool(moveTool);
                 moveTool->move(mouseX, mouseY);
                 moveTool->press(leftClick);


### PR DESCRIPTION
Hold down shift for vertically constrained movement, alt for horizontally
constrained movement, otherwise unconstrained.  This does not interfere with
the use of shift to extend the selection (or control to subtract from the
selection).