### PR TITLE
Fixed: qmake error: '***Unknown option -qt=qt5' and 'GStreamer; Unable to pause - ...'

### DIFF
--- a/building/build-linux.sh
+++ b/building/build-linux.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
-qmake -qt=qt5 -project -v
-qmake -qt=qt5 midieditor.pro
+QMAKE=`which qmake-qt5 2> /dev/null`
+QMAKE_ARGS=""
+if [ ! -x "$QMAKE" ];then
+    QMAKE=qmake
+    QMAKE_ARGS="-qt=qt5"
+fi
+"$QMAKE" $QMAKE_ARGS -project -v
+"$QMAKE" $QMAKE_ARGS midieditor.pro
 make
 status=$?
 if [ $status -eq 0 ]; then

--- a/src/midi/Metronome.cpp
+++ b/src/midi/Metronome.cpp
@@ -17,7 +17,7 @@ Metronome::Metronome(QObject *parent) :	QObject(parent) {
     denom = 2;
     _player = new QMediaPlayer(this, QMediaPlayer::LowLatency);
     _player->setVolume(100);
-    _player->setMedia(QUrl::fromLocalFile(QFileInfo("metronome/metronome-01.wav").absoluteFilePath()));
+    _player->setMedia(QUrl("qrc:/run_environment/metronome/metronome-01.wav"));
 }
 
 void Metronome::setFile(MidiFile *file){


### PR DESCRIPTION
	
  modified:   building/build-linux.sh
  modified:   src/midi/Metronome.cpp
1. In Fedora 31 (KDE), qmake error: '***Unknown option -qt=qt5' during build-process is fixed.

2. GStreamer; Unable to pause - "file:///.../metronome/metronome-01.wav" was fixed.