### PR TITLE
blue stripe in matrixwidget on sharps

### DIFF
--- a/src/gui/MatrixWidget.cpp
+++ b/src/gui/MatrixWidget.cpp
@@ -230,11 +230,12 @@ void MatrixWidget::paintEvent(QPaintEvent* event)
                 pianoKeys * lineHeight(), Qt::white);
         }
 
+
         // draw lines, pianokeys and linenames
         for (int i = startLineY; i <= endLineY; i++) {
             int startLine = yPosOfLine(i);
             QColor c(194, 230, 255);
-            if (i % 2 == 0) {
+            if ( !( (1 << (i % 12)) & sharp_strip_mask ) ){
                 c = QColor(234, 246, 255);
             }
 

--- a/src/gui/MatrixWidget.h
+++ b/src/gui/MatrixWidget.h
@@ -137,6 +137,9 @@ private:
     int _div;
 
     QMap<int, QRect> pianoKeys;
+
+    static const unsigned sharp_strip_mask = (1 << 4) | (1 << 6) | (1 << 9) | (1 << 11) | (1 << 1);
+
 };
 
 #endif


### PR DESCRIPTION
Hi There! 
I find the alternating stripes confusing in the matrix widget so I changed them so they are blue on the sharps and white for the naturals. I thought a bit mask would be an efficient way to make this work - I'm not 100% sure what data type it should be - I'm assuming "unsigned" is going to be 16 bit. 

This is what my edit looks like
![midieditor-strip](https://user-images.githubusercontent.com/1050038/82917742-b5e19b80-9f6b-11ea-95d4-f256c4b8d897.png)


Thanks for a great project!

Andy