### PR TITLE
magnet always snap to rasters when enabled

### DIFF
--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -323,24 +323,19 @@ int EventTool::pasteChannel()
 
 int EventTool::rasteredX(int x, int* tick)
 {
+    int t = _currentFile->tick(matrixWidget->msOfXPos(x));
     if (!_magnet) {
         if (tick) {
-            *tick = _currentFile->tick(matrixWidget->msOfXPos(x));
+            *tick = t;
         }
         return x;
-    }
-    typedef QPair<int, int> TMPPair;
-    foreach (TMPPair p, matrixWidget->divs()) {
-        int xt = p.first;
-        if (qAbs(xt - x) <= 5) {
-            if (tick) {
-                *tick = p.second;
-            }
-            return xt;
+    }else{
+        int tickdiv = _currentFile->ticksPerQuarter()*4/(int)qPow(2,matrixWidget->div());
+        t = ((int)(t/tickdiv)) * tickdiv;
+        if (tick){
+            *tick = t;
         }
-    }
-    if (tick) {
-        *tick = _currentFile->tick(matrixWidget->msOfXPos(x));
+        x = matrixWidget->xPosOfMs(matrixWidget->msOfTick(t));
     }
     return x;
 }


### PR DESCRIPTION
Hi There, 
Thanks for accepting my last update!

I've made a change to the magnet here. The magnet previously only worked if you were within 5px of a raster line, with this update the magnet forces quantization. This means to add a note with some swing you need to disable the magnet. I think this makes for a more deterministic workflow. An alternative I considered was to add another option 'magnet strength' but that made the gui cluttered. 

thanks 
Andy





