### PR TITLE
Copy-pasting between multiple instances of MidiEditor

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3240,7 +3240,7 @@ void MainWindow::toolChanged()
 
 void MainWindow::copiedEventsChanged()
 {
-    bool enable = EventTool::copiedEvents->size() > 0;
+    bool enable = true;//EventTool::copiedEvents->size() > 0;
     _pasteAction->setEnabled(enable);
     pasteActionTB->setEnabled(enable);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -502,7 +502,7 @@ MainWindow::MainWindow(QString initFile)
     } else {
         colorsByTrack();
     }
-    copiedEventsChanged();
+    //copiedEventsChanged();
     setAcceptDrops(true);
 
     currentTweakTarget = new TimeTweakTarget(this);
@@ -3238,12 +3238,12 @@ void MainWindow::toolChanged()
     mw_matrixWidget->update();
 }
 
-void MainWindow::copiedEventsChanged()
+/*void MainWindow::copiedEventsChanged()
 {
     bool enable = true;//EventTool::copiedEvents->size() > 0;
     _pasteAction->setEnabled(enable);
     pasteActionTB->setEnabled(enable);
-}
+}*/
 
 void MainWindow::updateDetected(Update* update)
 {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -174,7 +174,7 @@ public slots:
 
     void checkEnableActionsForSelection();
     void toolChanged();
-    void copiedEventsChanged();
+    //void copiedEventsChanged();
 
     void updateDetected(Update* update);
     void promtUpdatesDeactivatedDialog();

--- a/src/midi/MidiFile.cpp
+++ b/src/midi/MidiFile.cpp
@@ -129,7 +129,7 @@ MidiFile::MidiFile(QString path, bool* ok, QStringList* log)
     printLog(log);
 }
 
-MidiFile::MidiFile(QByteArray raw_midi, bool* ok, QStringList* log)
+MidiFile::MidiFile(QByteArray& raw_midi, bool* ok, QStringList* log)
 {
 
     if (!log) {

--- a/src/midi/MidiFile.cpp
+++ b/src/midi/MidiFile.cpp
@@ -37,6 +37,7 @@
 #include "math.h"
 
 #include <QtCore/qmath.h>
+#include <iostream>
 
 int MidiFile::defaultTimePerQuarter = 192;
 
@@ -115,6 +116,40 @@ MidiFile::MidiFile(QString path, bool* ok, QStringList* log)
     }
 
     QDataStream* stream = new QDataStream(f);
+    stream->setByteOrder(QDataStream::BigEndian);
+    if (!readMidiFile(stream, log)) {
+        *ok = false;
+        printLog(log);
+        return;
+    }
+
+    *ok = true;
+    playerMap = new QMultiMap<int, MidiEvent*>;
+    calcMaxTime();
+    printLog(log);
+}
+
+MidiFile::MidiFile(QByteArray raw_midi, bool* ok, QStringList* log)
+{
+
+    if (!log) {
+        log = new QStringList();
+    }
+
+    _pauseTick = -1;
+    _saved = false;
+    midiTicks = 0;
+    _cursorTick = 0;
+    prot = new Protocol(this);
+    prot->addEmptyAction("File opened");
+    _tracks = new QList<MidiTrack*>();
+
+
+    for (int i = 0; i < 19; i++) {
+        channels[i] = new MidiChannel(this, i);
+    }
+
+    QDataStream* stream = new QDataStream(raw_midi);
     stream->setByteOrder(QDataStream::BigEndian);
     if (!readMidiFile(stream, log)) {
         *ok = false;
@@ -1424,18 +1459,7 @@ void MidiFile::setPauseTick(int tick)
     _pauseTick = tick;
 }
 
-bool MidiFile::save(QString path)
-{
-
-    QFile* f = new QFile(path);
-
-    if (!f->open(QIODevice::WriteOnly)) {
-        return false;
-    }
-
-    QDataStream* stream = new QDataStream(f);
-    stream->setByteOrder(QDataStream::BigEndian);
-
+QByteArray MidiFile::toByteArray(){
     // All Events are stored in allEvents. This is because the data has to be
     // saved by tracks and not by channels
     QMultiMap<int, MidiEvent*> allEvents = QMultiMap<int, MidiEvent*>();
@@ -1527,6 +1551,22 @@ bool MidiFile::save(QString path)
             data[trackLengthPos + 3 - i] = ((qint8)((numBytes & (0xFF << 8 * i)) >> 8 * i));
         }
     }
+    return data;
+}
+
+bool MidiFile::save(QString path)
+{
+
+    QFile* f = new QFile(path);
+
+    if (!f->open(QIODevice::WriteOnly)) {
+        return false;
+    }
+
+    QDataStream* stream = new QDataStream(f);
+    stream->setByteOrder(QDataStream::BigEndian);
+
+    QByteArray data = toByteArray();
 
     // write data to the filestream
     for (int i = 0; i < data.count(); i++) {

--- a/src/midi/MidiFile.cpp
+++ b/src/midi/MidiFile.cpp
@@ -703,6 +703,12 @@ int MidiFile::ticksPerQuarter()
     return timePerQuarter;
 }
 
+void MidiFile::setTicksPerQuarter(int timePerQuarter)
+{
+    this->timePerQuarter = timePerQuarter;
+}
+
+
 QMultiMap<int, MidiEvent*>* MidiFile::channelEvents(int channel)
 {
     return channels[channel]->eventMap();

--- a/src/midi/MidiFile.h
+++ b/src/midi/MidiFile.h
@@ -38,7 +38,7 @@ class MidiFile : public QObject, public ProtocolEntry {
     Q_OBJECT
 
 public:
-    MidiFile(QByteArray raw_midi, bool* ok, QStringList* log);
+    MidiFile(QByteArray& raw_midi, bool* ok, QStringList* log);
     MidiFile(QString path, bool* ok, QStringList* log = 0);
     MidiFile();
     // needed to protocol fileLength

--- a/src/midi/MidiFile.h
+++ b/src/midi/MidiFile.h
@@ -38,12 +38,14 @@ class MidiFile : public QObject, public ProtocolEntry {
     Q_OBJECT
 
 public:
+    MidiFile(QByteArray raw_midi, bool* ok, QStringList* log);
     MidiFile(QString path, bool* ok, QStringList* log = 0);
     MidiFile();
     // needed to protocol fileLength
     MidiFile(int maxTime, Protocol* p);
     bool save(QString path);
-    QByteArray writeDeltaTime(int time);
+    QByteArray toByteArray();
+    static QByteArray writeDeltaTime(int time);
     int maxTime();
     int endTick();
     int timeMS(int midiTime);

--- a/src/midi/MidiFile.h
+++ b/src/midi/MidiFile.h
@@ -60,6 +60,7 @@ public:
 
     QList<MidiEvent*>* eventsBetween(int start, int end);
     int ticksPerQuarter();
+    void setTicksPerQuarter(int timePerQuarter);
     QMultiMap<int, MidiEvent*>* channelEvents(int channel);
 
     Protocol* protocol();

--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -36,8 +36,6 @@
 #include <QtCore/qmath.h>
 #include <QClipboard>
 #include <QMessageBox>
-#include <iostream>
-#include <limits>
 
 
 QList<MidiEvent*>* EventTool::copiedEvents = new QList<MidiEvent*>;
@@ -196,37 +194,21 @@ void EventTool::copyAction()
                 }
             }
         }
-        //std::cout << "Copied " << copiedEvents->size() << std::endl;
-
         MidiFile copyFile = MidiFile();
-        
-        //auto copyFileEventList = copyFile.channelEvents(1);
-        //MidiChannel* copyChannel = copyFile.channel(0);
-
-        //int channel = copiedEvents->at(0)->channel();
-        /*std::cout << "Cchannel: " << channel << "\n";
-        auto events = copiedEvents->at(0)->file()->channel(channel)->eventMap();
-        auto it = events->keyValueBegin();
-        while (it != events->keyValueEnd()){
-            std::cout << it->first << ", " << it->second->midiTime() << std::endl;
-            it++;
-        }*/
+        MidiTrack* copyTrack = copyFile.track(1);
 
         for (auto event: *copiedEvents){
-            MidiEvent* copy = dynamic_cast<MidiEvent*>(event->copy()); //new MidiEvent(*event);
-            copy->setTrack(copyFile.track(1), false);
+            MidiEvent* copy = dynamic_cast<MidiEvent*>(event->copy());
+            copy->setTrack(copyTrack, false);
             copy->setChannel(0, false);
             copy->setFile(&copyFile);
             copyFile.channelEvents(0)->insert(event->midiTime(), copy);
         }
-        //std::cout << copyFile.numTracks() << std::endl;
 
         QClipboard *clipboard = QGuiApplication::clipboard();
         clipboard->setText(copyFile.toByteArray().toBase64());
-        
-        //std::cout <<  << std::endl;
 
-        _mainWindow->copiedEventsChanged();
+        //_mainWindow->copiedEventsChanged();
     }
 }
 

--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -167,12 +167,12 @@ void EventTool::changeTick(MidiEvent* event, int shiftX)
 
 void EventTool::copyAction()
 {
-    MidiFile copyFile = MidiFile();
-    MidiTrack* copyTrack = copyFile.track(1);
-
     if (Selection::instance()->selectedEvents().size() > 0) {
         // clear old copied Events
         //copiedEvents->clear();
+        MidiFile copyFile = MidiFile();
+        copyFile.setTicksPerQuarter(Selection::instance()->selectedEvents().first()->file()->ticksPerQuarter());
+        MidiTrack* copyTrack = copyFile.track(1);
 
         foreach (MidiEvent* event, Selection::instance()->selectedEvents()) {
 

--- a/src/tool/EventTool.h
+++ b/src/tool/EventTool.h
@@ -22,6 +22,7 @@
 #include "EditorTool.h"
 
 #include <QList>
+#include <QSharedMemory>
 
 class MidiEvent;
 class MidiTrack;
@@ -54,13 +55,14 @@ public:
     static void enableMagnet(bool enable);
     static bool magnetEnabled();
 
-    static QList<MidiEvent*>* copiedEvents;
+    //static QList<MidiEvent*>* copiedEvents;
 
 protected:
     static bool isCutAction;
     static int _pasteChannel;
     static int _pasteTrack;
     static bool _magnet;
+    static QSharedMemory sharedMemory;
 };
 
 #endif


### PR DESCRIPTION
This is currently not possible as copied events are simply stored in a variable of each instance of MidiEditor. 

I added this feature by converting the selected events into a `MidiFile` object and saving this in `QSharedMemory`. 
When pasting, the reverse happens. See the commit message and the subsequent comment for more details.

This would resolve #84.