### PR TITLE
Fixes for performance and memory allocation problems

### DIFF
--- a/src/MidiEvent/MidiEvent.cpp
+++ b/src/MidiEvent/MidiEvent.cpp
@@ -401,7 +401,12 @@ void MidiEvent::setMidiTime(int t, bool toProtocol)
         }
     }
 
-    ProtocolEntry* toCopy = copy();
+    ProtocolEntry* toCopy = nullptr;
+    if (toProtocol)
+    {
+        toCopy = copy();
+    }
+
     file()->channelEvents(numChannel)->remove(timePos, this);
     timePos = t;
     if (timePos > file()->endTick()) {
@@ -409,8 +414,6 @@ void MidiEvent::setMidiTime(int t, bool toProtocol)
     }
     if (toProtocol) {
         protocol(toCopy, this);
-    } else {
-        delete toCopy;
     }
 
     file()->channelEvents(numChannel)->insert(timePos, this);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1466,6 +1466,7 @@ void MainWindow::deleteChannel(QAction* action)
             EventTool::deselectEvent(event);
         }
     }
+    Selection::instance()->setSelection(Selection::instance()->selectedEvents());
 
     file->channel(num)->deleteAllEvents();
     file->protocol()->endAction();
@@ -1796,6 +1797,7 @@ void MainWindow::removeTrack(int tracknumber)
             EventTool::deselectEvent(event);
         }
     }
+    Selection::instance()->setSelection(Selection::instance()->selectedEvents());
     if (!file->removeTrack(track)) {
         QMessageBox::warning(this, "Error", QString("The selected track can\'t be removed!\n It\'s the last track of the file."));
     }
@@ -1910,8 +1912,9 @@ void MainWindow::selectAllFromChannel(QAction* action)
         if (e->track()->hidden()) {
             e->track()->setHidden(false);
         }
-        EventTool::selectEvent(e, false);
+        EventTool::selectEvent(e, false, false, false);
     }
+    Selection::instance()->setSelection(Selection::instance()->selectedEvents());
 
     file->protocol()->endAction();
 }
@@ -1931,10 +1934,11 @@ void MainWindow::selectAllFromTrack(QAction* action)
         foreach (MidiEvent* e, file->channel(channel)->eventMap()->values()) {
             if (e->track()->number() == track) {
                 file->channel(e->channel())->setVisible(true);
-                EventTool::selectEvent(e, false);
+                EventTool::selectEvent(e, false, false, false);
             }
         }
     }
+    Selection::instance()->setSelection(Selection::instance()->selectedEvents());    
     file->protocol()->endAction();
 }
 
@@ -1949,9 +1953,10 @@ void MainWindow::selectAll()
 
     for (int i = 0; i < 16; i++) {
         foreach (MidiEvent* event, file->channel(i)->eventMap()->values()) {
-            EventTool::selectEvent(event, false, true);
+            EventTool::selectEvent(event, false, true, false);
         }
     }
+    Selection::instance()->setSelection(Selection::instance()->selectedEvents());
 
     file->protocol()->endAction();
 }

--- a/src/midi/MidiChannel.cpp
+++ b/src/midi/MidiChannel.cpp
@@ -184,12 +184,20 @@ bool MidiChannel::removeEvent(MidiEvent* event)
     return true;
 }
 
-void MidiChannel::insertEvent(MidiEvent* event, int tick)
+void MidiChannel::insertEvent(MidiEvent* event, int tick, bool toProtocol)
 {
-    ProtocolEntry* toCopy = copy();
+    ProtocolEntry* toCopy = nullptr;
+    if (toProtocol)
+    {
+        toCopy = copy();
+    }
     event->setFile(file());
     event->setMidiTime(tick, false);
-    protocol(toCopy, this);
+
+    if (toProtocol)
+    {
+        protocol(toCopy, this);
+    }
 }
 
 void MidiChannel::deleteAllEvents()

--- a/src/midi/MidiChannel.h
+++ b/src/midi/MidiChannel.h
@@ -101,7 +101,7 @@ public:
     /**
 		 * \brief inserts event into the channels map.
 		 */
-    void insertEvent(MidiEvent* event, int tick);
+    void insertEvent(MidiEvent* event, int tick, bool toProtocol = true);
 
     /**
 		 * \brief removes event from the eventMap.

--- a/src/tool/EraserTool.cpp
+++ b/src/tool/EraserTool.cpp
@@ -80,6 +80,7 @@ bool EraserTool::release()
             }
         }
     }
+    Selection::instance()->setSelection(Selection::instance()->selectedEvents());
     currentProtocol()->endAction();
     return true;
 }

--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -63,7 +63,7 @@ void EventTool::selectEvent(MidiEvent* event, bool single, bool ignoreStr)
         return;
     }
 
-    QList<MidiEvent*> selected = Selection::instance()->selectedEvents();
+    QList<MidiEvent*>& selected = Selection::instance()->selectedEvents();
 
     OffEvent* offevent = dynamic_cast<OffEvent*>(event);
     if (offevent) {
@@ -83,7 +83,6 @@ void EventTool::selectEvent(MidiEvent* event, bool single, bool ignoreStr)
         selected.removeAll(event);
     }
 
-    Selection::instance()->setSelection(selected);
     _mainWindow->eventWidget()->reportSelectionChangedByTool();
 }
 
@@ -92,7 +91,6 @@ void EventTool::deselectEvent(MidiEvent* event)
 
     QList<MidiEvent*> selected = Selection::instance()->selectedEvents();
     selected.removeAll(event);
-    Selection::instance()->setSelection(selected);
 
     if (_mainWindow->eventWidget()->events().contains(event)) {
         _mainWindow->eventWidget()->removeEvent(event);

--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -54,7 +54,7 @@ EventTool::EventTool(EventTool& other)
 {
 }
 
-void EventTool::selectEvent(MidiEvent* event, bool single, bool ignoreStr)
+void EventTool::selectEvent(MidiEvent* event, bool single, bool ignoreStr, bool setSelection)
 {
 
     if (!event->file()->channel(event->channel())->visible()) {
@@ -85,13 +85,17 @@ void EventTool::selectEvent(MidiEvent* event, bool single, bool ignoreStr)
         selected.removeAll(event);
     }
 
+    if (setSelection)
+    {
+        Selection::instance()->setSelection(selected);
+    }
     _mainWindow->eventWidget()->reportSelectionChangedByTool();
 }
 
 void EventTool::deselectEvent(MidiEvent* event)
 {
 
-    QList<MidiEvent*> selected = Selection::instance()->selectedEvents();
+    QList<MidiEvent*>& selected = Selection::instance()->selectedEvents();
     selected.removeAll(event);
 
     if (_mainWindow->eventWidget()->events().contains(event)) {
@@ -317,8 +321,9 @@ void EventTool::pasteAction()
             event->setTrack(track, false);
             currentFile()->channel(channelNum)->insertEvent(event,
                 (int)(tickscale * event->midiTime()) + diff, false);
-            selectEvent(event, false, true);
+            selectEvent(event, false, true, false);
         }
+        Selection::instance()->setSelection(Selection::instance()->selectedEvents());
 
         // Put the copied channels from before the event insertion onto the protocol stack
         for (auto channelPair : channelCopies)

--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -254,7 +254,9 @@ void EventTool::pasteAction()
         // set the Positions and add the Events to the channels
         clearSelection();
 
-        foreach (MidiEvent* event, copiedCopiedEvents) {
+        std::sort(copiedCopiedEvents.begin(), copiedCopiedEvents.end(), [](MidiEvent* a, MidiEvent* b){ return a->midiTime() < b->midiTime(); });
+        for (auto it = copiedCopiedEvents.rbegin(); it != copiedCopiedEvents.rend(); it++) {
+            MidiEvent* event = *it;
 
             // get channel
             int channel = event->channel();

--- a/src/tool/EventTool.h
+++ b/src/tool/EventTool.h
@@ -32,7 +32,7 @@ public:
     EventTool();
     EventTool(EventTool& other);
 
-    static void selectEvent(MidiEvent* event, bool single, bool ignoreStr = false);
+    static void selectEvent(MidiEvent* event, bool single, bool ignoreStr = false, bool setSelection = true);
     static void deselectEvent(MidiEvent* event);
     static void clearSelection();
     void paintSelectedEvents(QPainter* painter);

--- a/src/tool/SelectTool.cpp
+++ b/src/tool/SelectTool.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "SelectTool.h"
+#include "Selection.h"
 #include "../MidiEvent/MidiEvent.h"
 #include "../MidiEvent/NoteOnEvent.h"
 #include "../gui/MatrixWidget.h"
@@ -131,9 +132,10 @@ bool SelectTool::release()
         }
         foreach (MidiEvent* event, *(matrixWidget->activeEvents())) {
             if (inRect(event, x_start, y_start, x_end, y_end)) {
-                selectEvent(event, false);
+                selectEvent(event, false, false, false);
             }
         }
+        Selection::instance()->setSelection(Selection::instance()->selectedEvents());
     } else if (stool_type == SELECTION_TYPE_RIGHT || stool_type == SELECTION_TYPE_LEFT) {
         int tick = file()->tick(matrixWidget->msOfXPos(mouseX));
         int start, end;
@@ -145,8 +147,9 @@ bool SelectTool::release()
             start = tick;
         }
         foreach (MidiEvent* event, *(file()->eventsBetween(start, end))) {
-            selectEvent(event, false);
+            selectEvent(event, false, false, false);
         }
+        Selection::instance()->setSelection(Selection::instance()->selectedEvents());
     }
 
     x_rect = 0;

--- a/src/tool/Selection.cpp
+++ b/src/tool/Selection.cpp
@@ -54,7 +54,7 @@ void Selection::setFile(MidiFile* file)
     _selectionInstance = new Selection(file);
 }
 
-QList<MidiEvent*> Selection::selectedEvents()
+QList<MidiEvent*>& Selection::selectedEvents()
 {
     return _selectedEvents;
 }

--- a/src/tool/Selection.cpp
+++ b/src/tool/Selection.cpp
@@ -61,9 +61,9 @@ QList<MidiEvent*>& Selection::selectedEvents()
 
 void Selection::setSelection(QList<MidiEvent*> selections)
 {
-    ProtocolEntry* toCopy = copy();
+    protocol(copy(), this);
+
     _selectedEvents = selections;
-    protocol(toCopy, this);
     if (_eventWidget) {
         _eventWidget->setEvents(_selectedEvents);
         //_eventWidget->reload();

--- a/src/tool/Selection.h
+++ b/src/tool/Selection.h
@@ -21,7 +21,7 @@ public:
     static Selection* instance();
     static void setFile(MidiFile* file);
 
-    QList<MidiEvent*> selectedEvents();
+    QList<MidiEvent*>& selectedEvents();
     void setSelection(QList<MidiEvent*> selections);
     void clearSelection();
 


### PR DESCRIPTION
When inserting a large amount of events (several thousand) into a file, I discovered that the insertion takes a very long time and the allocated memory increases massively to over a GB. To reproduce, just load a file with > 5000 events, copy the events, open a new file, and paste the events. Watch memory and the CPU load in the task manager.
Basically this is about preventing unnecessary copying of midi events and channels.
See the individual commits for details.